### PR TITLE
Add noNullOr operator

### DIFF
--- a/lib/extendedFiniteStateMachine.js
+++ b/lib/extendedFiniteStateMachine.js
@@ -5,13 +5,15 @@ const operatorAnsweredLessThan = require('./operators/operatorAnsweredLessThan')
 const operatorDateExceedsTwoYearsFromNow = require('./operators/operatorDateExceedsTwoYearsFromNow');
 const operatorDateLessThanEighteenYearsAgo = require('./operators/operatorDateLessThanEighteenYearsAgo');
 const operatorDateGreaterThanTwoDays = require('./operators/operatorDateDifferenceGreaterThanTwoDays');
-const operatorNoNullOr = require('./operators/operatorNoNullOr');
+const operatorOrNullIsFalse = require('./operators/operatorOrNullIsFalse');
+const operatorIncludesNullIsFalse = require('./operators/operatorIncludesNullIsFalse');
 
 jr.addOperator('answeredLessThan', operatorAnsweredLessThan, true);
 jr.addOperator('dateExceedsTwoYearsFromNow', operatorDateExceedsTwoYearsFromNow);
 jr.addOperator('dateLessThanEighteenYearsAgo', operatorDateLessThanEighteenYearsAgo);
 jr.addOperator('dateDifferenceGreaterThanTwoDays', operatorDateGreaterThanTwoDays, true);
-jr.addOperator('noNullOr', operatorNoNullOr, true);
+jr.addOperator('orNullIsFalse', operatorOrNullIsFalse, true);
+jr.addOperator('includesNullIsFalse', operatorIncludesNullIsFalse, true);
 
 function createMachine(spec) {
     const {

--- a/lib/extendedFiniteStateMachine.js
+++ b/lib/extendedFiniteStateMachine.js
@@ -5,11 +5,13 @@ const operatorAnsweredLessThan = require('./operators/operatorAnsweredLessThan')
 const operatorDateExceedsTwoYearsFromNow = require('./operators/operatorDateExceedsTwoYearsFromNow');
 const operatorDateLessThanEighteenYearsAgo = require('./operators/operatorDateLessThanEighteenYearsAgo');
 const operatorDateGreaterThanTwoDays = require('./operators/operatorDateDifferenceGreaterThanTwoDays');
+const operatorNoNullOr = require('./operators/operatorNoNullOr');
 
 jr.addOperator('answeredLessThan', operatorAnsweredLessThan, true);
 jr.addOperator('dateExceedsTwoYearsFromNow', operatorDateExceedsTwoYearsFromNow);
 jr.addOperator('dateLessThanEighteenYearsAgo', operatorDateLessThanEighteenYearsAgo);
 jr.addOperator('dateDifferenceGreaterThanTwoDays', operatorDateGreaterThanTwoDays, true);
+jr.addOperator('noNullOr', operatorNoNullOr, true);
 
 function createMachine(spec) {
     const {

--- a/lib/extendedFiniteStateMachine.js
+++ b/lib/extendedFiniteStateMachine.js
@@ -19,24 +19,6 @@ function createMachine(spec) {
     const {
         states,
         evaluateCondition = (cond, extendedStateObject /* , eventObject, sectionId, guard */) => {
-            console.log(json.stringify(cond, null, 4));
-            console.log(`
-            
-            
-            
-            
-            
-            
-            ------------------------------------------------------------------------------
-            
-            
-            
-            
-            
-            
-            
-            `);
-            console.log(json.stringify(extendedStateObject, null, 4));
             jr.evaluate(cond, extendedStateObject)
         }
     } = spec;

--- a/lib/extendedFiniteStateMachine.js
+++ b/lib/extendedFiniteStateMachine.js
@@ -18,8 +18,27 @@ jr.addOperator('includesNullIsFalse', operatorIncludesNullIsFalse, true);
 function createMachine(spec) {
     const {
         states,
-        evaluateCondition = (cond, extendedStateObject /* , eventObject, sectionId, guard */) =>
+        evaluateCondition = (cond, extendedStateObject /* , eventObject, sectionId, guard */) => {
+            console.log(json.stringify(cond, null, 4));
+            console.log(`
+            
+            
+            
+            
+            
+            
+            ------------------------------------------------------------------------------
+            
+            
+            
+            
+            
+            
+            
+            `);
+            console.log(json.stringify(extendedStateObject, null, 4));
             jr.evaluate(cond, extendedStateObject)
+        }
     } = spec;
     const initialState = {
         value: spec.initial,

--- a/lib/operators/operatorIncludesNullIsFalse.js
+++ b/lib/operators/operatorIncludesNullIsFalse.js
@@ -1,0 +1,16 @@
+'use strict';
+
+function includesNullIsFalse(rule, data) {
+    const {answers} = data;
+    const question = rule[1].split('.')[3];
+    let hasValue = false;
+    Object.keys(answers).forEach(page => {
+        if (question in answers[page]) {
+            hasValue = answers[page][question].includes(rule[2]);
+        }
+    });
+
+    return hasValue;
+}
+
+module.exports = includesNullIsFalse;

--- a/lib/operators/operatorNoNullOr.js
+++ b/lib/operators/operatorNoNullOr.js
@@ -1,0 +1,25 @@
+'use strict';
+
+function noNullOr(rule, data) {
+    function findAnswers(answers, questionObject) {
+        const question = questionObject.split('.')[3];
+        let value = false;
+        Object.keys(answers).forEach(page => {
+            if (question in answers[page]) {
+                value = answers[page][question];
+            }
+        });
+        return value;
+    }
+
+    const {answers} = data;
+    let returnValue = false;
+    for (let i=1; i<rule.length; i++){
+        let answerFoundAndTrue = findAnswers(answers, rule[i]);
+        returnValue = answerFoundAndTrue ? true : returnValue
+    }
+
+    return returnValue;
+}
+
+module.exports = noNullOr;

--- a/lib/operators/operatorOrNullIsFalse.js
+++ b/lib/operators/operatorOrNullIsFalse.js
@@ -1,6 +1,6 @@
 'use strict';
 
-function noNullOr(rule, data) {
+function orNullIsFalse(rule, data) {
     function findAnswers(answers, questionObject) {
         const question = questionObject.split('.')[3];
         let value = false;
@@ -22,4 +22,4 @@ function noNullOr(rule, data) {
     return returnValue;
 }
 
-module.exports = noNullOr;
+module.exports = orNullIsFalse;

--- a/package-lock.json
+++ b/package-lock.json
@@ -4111,8 +4111,8 @@
             "dev": true
         },
         "json-rules": {
-            "version": "github:webstacker/json-rules#ea09a0ae33437b985d20af683577a5a1f31d834a",
-            "from": "github:webstacker/json-rules#v0.3.0"
+            "version": "github:CriminalInjuriesCompensationAuthority/json-rules#a683119602f6a3ee89a3ca563f599c592092bcf6",
+            "from": "github:CriminalInjuriesCompensationAuthority/json-rules#nullIsFalse"
         },
         "json-schema": {
             "version": "0.2.3",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     },
     "license": "MIT",
     "dependencies": {
-        "json-rules": "github:webstacker/json-rules#v0.3.0",
+        "json-rules": "github:CriminalInjuriesCompensationAuthority/json-rules#nullIsFalse",
         "moment": "^2.24.0"
     },
     "_m0": {

--- a/test/routing.test.js
+++ b/test/routing.test.js
@@ -1108,7 +1108,7 @@ describe('qRouter tests', () => {
                 expect(nextSectionId).toEqual('section2');
             });
 
-            it('should return true if noNullOr and any answer is true', () => {
+            it('should return true if orNullIsFalse and any answer is true', () => {
                 const router = qRouter({
                     routes: {
                         initial: 'section1',
@@ -1137,7 +1137,7 @@ describe('qRouter tests', () => {
                                         {
                                             target: 'section4',
                                             cond: [
-                                                'noNullOr',
+                                                'orNullIsFalse',
                                                 '$.answers.section1.q1',
                                                 '$.answers.section2.q2',
                                                 '$.answers.section3.q3'
@@ -1161,7 +1161,7 @@ describe('qRouter tests', () => {
                 expect(nextSectionId).toEqual('section4');
             });
 
-            it('should return false if noNullOr all answers are false', () => {
+            it('should return false if orNullIsFalse all answers are false', () => {
                 const router = qRouter({
                     routes: {
                         initial: 'section1',
@@ -1190,7 +1190,7 @@ describe('qRouter tests', () => {
                                         {
                                             target: 'section4',
                                             cond: [
-                                                'noNullOr',
+                                                'orNullIsFalse',
                                                 '$.answers.section1.q1',
                                                 '$.answers.section2.q2',
                                                 '$.answers.section3.q3'
@@ -1214,7 +1214,7 @@ describe('qRouter tests', () => {
                 expect(nextSectionId).toEqual('section5');
             });
 
-            it('should return false if noNullOr all answers are false and some answers are null', () => {
+            it('should return false if orNullIsFalse all answers are false and some answers are null', () => {
                 const router = qRouter({
                     routes: {
                         initial: 'section1',
@@ -1243,7 +1243,7 @@ describe('qRouter tests', () => {
                                         {
                                             target: 'section4',
                                             cond: [
-                                                'noNullOr',
+                                                'orNullIsFalse',
                                                 '$.answers.section1.q1',
                                                 '$.answers.section2.q2',
                                                 '$.answers.nullSection.nullQuestion'
@@ -1267,7 +1267,7 @@ describe('qRouter tests', () => {
                 expect(nextSectionId).toEqual('section5');
             });
 
-            it('should return true if noNullOr any answer is true and some answers are null', () => {
+            it('should return true if orNullIsFalse any answer is true and some answers are null', () => {
                 const router = qRouter({
                     routes: {
                         initial: 'section1',
@@ -1296,7 +1296,7 @@ describe('qRouter tests', () => {
                                         {
                                             target: 'section4',
                                             cond: [
-                                                'noNullOr',
+                                                'orNullIsFalse',
                                                 '$.answers.nullSection.nullQuestion',
                                                 '$.answers.section1.q1',
                                                 '$.answers.section2.q2',
@@ -1319,6 +1319,102 @@ describe('qRouter tests', () => {
                 const nextSectionId = router.next({q3: false}).id;
 
                 expect(nextSectionId).toEqual('section4');
+            });
+
+            it('should return true if includesNullIsFalse and the answer includes the search value', () => {
+                const router = qRouter({
+                    routes: {
+                        initial: 'section1',
+                        states: {
+                            section1: {
+                                on: {
+                                    ANSWER: [
+                                        {
+                                            target: 'section2',
+                                            cond: [
+                                                'includesNullIsFalse',
+                                                '$.answers.section1.q1',
+                                                'value-one'
+                                            ]
+                                        },
+                                        {
+                                            target: 'section3'
+                                        }
+                                    ]
+                                }
+                            },
+                            section2: {},
+                            section3: {}
+                        }
+                    }
+                });
+                const nextSectionId = router.next({q1: ['value-one', 'value-two']}).id;
+
+                expect(nextSectionId).toEqual('section2');
+            });
+
+            it('should return false if includesNullIsFalse and the answer does not include the search value', () => {
+                const router = qRouter({
+                    routes: {
+                        initial: 'section1',
+                        states: {
+                            section1: {
+                                on: {
+                                    ANSWER: [
+                                        {
+                                            target: 'section2',
+                                            cond: [
+                                                'includesNullIsFalse',
+                                                '$.answers.section1.q1',
+                                                'value-other'
+                                            ]
+                                        },
+                                        {
+                                            target: 'section3'
+                                        }
+                                    ]
+                                }
+                            },
+                            section2: {},
+                            section3: {}
+                        }
+                    }
+                });
+                const nextSectionId = router.next({q1: ['value-one', 'value-two']}).id;
+
+                expect(nextSectionId).toEqual('section3');
+            });
+
+            it('should return false if includesNullIsFalse and the answer being searched for is null', () => {
+                const router = qRouter({
+                    routes: {
+                        initial: 'section1',
+                        states: {
+                            section1: {
+                                on: {
+                                    ANSWER: [
+                                        {
+                                            target: 'section2',
+                                            cond: [
+                                                'includesNullIsFalse',
+                                                '$.answers.other-section.q-other',
+                                                'value-one'
+                                            ]
+                                        },
+                                        {
+                                            target: 'section3'
+                                        }
+                                    ]
+                                }
+                            },
+                            section2: {},
+                            section3: {}
+                        }
+                    }
+                });
+                const nextSectionId = router.next({q1: ['value-one', 'value-two']}).id;
+
+                expect(nextSectionId).toEqual('section3');
             });
         });
     });

--- a/test/routing.test.js
+++ b/test/routing.test.js
@@ -1044,6 +1044,282 @@ describe('qRouter tests', () => {
 
                 expect(nextSectionId).toEqual('section4');
             });
+
+            it('should return true if dateMoreThanEighteenYearsAgo and date entered is more than 18 years ago', () => {
+                const router = qRouter({
+                    routes: {
+                        initial: 'section1',
+                        states: {
+                            section1: {
+                                on: {
+                                    ANSWER: [
+                                        {
+                                            target: 'section2',
+                                            cond: [
+                                                'dateMoreThanEighteenYearsAgo',
+                                                '$.answers.section1.q1'
+                                            ]
+                                        },
+                                        {
+                                            target: 'section3'
+                                        }
+                                    ]
+                                }
+                            },
+                            section2: {},
+                            section3: {}
+                        }
+                    }
+                });
+
+                const nextSectionId = router.next({q1: '2000-02-01T00:00Z'}).id;
+
+                expect(nextSectionId).toEqual('section2');
+            });
+
+            it('should return false if dateMoreThanEighteenYearsAgo and date entered is less than 18 years ago', () => {
+                const router = qRouter({
+                    routes: {
+                        initial: 'section1',
+                        states: {
+                            section1: {
+                                on: {
+                                    ANSWER: [
+                                        {
+                                            target: 'section2',
+                                            cond: [
+                                                'dateLessThanEighteenYearsAgo',
+                                                '$.answers.section1.q1'
+                                            ]
+                                        },
+                                        {
+                                            target: 'section3'
+                                        }
+                                    ]
+                                }
+                            },
+                            section2: {},
+                            section3: {}
+                        }
+                    }
+                });
+                const nextSectionId = router.next({q1: '2015-02-01T00:00Z'}).id;
+
+                expect(nextSectionId).toEqual('section2');
+            });
+
+            it('should return true if noNullOr and any answer is true', () => {
+                const router = qRouter({
+                    routes: {
+                        initial: 'section1',
+                        states: {
+                            section1: {
+                                on: {
+                                    ANSWER: [
+                                        {
+                                            target: 'section2'
+                                        }
+                                    ]
+                                }
+                            },
+                            section2: {
+                                on: {
+                                    ANSWER: [
+                                        {
+                                            target: 'section3'
+                                        }
+                                    ]
+                                }
+                            },
+                            section3: {
+                                on: {
+                                    ANSWER: [
+                                        {
+                                            target: 'section4',
+                                            cond: [
+                                                'noNullOr',
+                                                '$.answers.section1.q1',
+                                                '$.answers.section2.q2',
+                                                '$.answers.section3.q3'
+                                            ]
+                                        },
+                                        {
+                                            target: 'section5'
+                                        }
+                                    ]
+                                }
+                            },
+                            section4: {},
+                            section5: {}
+                        }
+                    }
+                });
+                router.next({q1: false});
+                router.next({q2: false});
+                const nextSectionId = router.next({q3: true}).id;
+
+                expect(nextSectionId).toEqual('section4');
+            });
+
+            it('should return false if noNullOr all answers are false', () => {
+                const router = qRouter({
+                    routes: {
+                        initial: 'section1',
+                        states: {
+                            section1: {
+                                on: {
+                                    ANSWER: [
+                                        {
+                                            target: 'section2'
+                                        }
+                                    ]
+                                }
+                            },
+                            section2: {
+                                on: {
+                                    ANSWER: [
+                                        {
+                                            target: 'section3'
+                                        }
+                                    ]
+                                }
+                            },
+                            section3: {
+                                on: {
+                                    ANSWER: [
+                                        {
+                                            target: 'section4',
+                                            cond: [
+                                                'noNullOr',
+                                                '$.answers.section1.q1',
+                                                '$.answers.section2.q2',
+                                                '$.answers.section3.q3'
+                                            ]
+                                        },
+                                        {
+                                            target: 'section5'
+                                        }
+                                    ]
+                                }
+                            },
+                            section4: {},
+                            section5: {}
+                        }
+                    }
+                });
+                router.next({q1: false});
+                router.next({q2: false});
+                const nextSectionId = router.next({q3: false}).id;
+
+                expect(nextSectionId).toEqual('section5');
+            });
+
+            it('should return false if noNullOr all answers are false and some answers are null', () => {
+                const router = qRouter({
+                    routes: {
+                        initial: 'section1',
+                        states: {
+                            section1: {
+                                on: {
+                                    ANSWER: [
+                                        {
+                                            target: 'section2'
+                                        }
+                                    ]
+                                }
+                            },
+                            section2: {
+                                on: {
+                                    ANSWER: [
+                                        {
+                                            target: 'section3'
+                                        }
+                                    ]
+                                }
+                            },
+                            section3: {
+                                on: {
+                                    ANSWER: [
+                                        {
+                                            target: 'section4',
+                                            cond: [
+                                                'noNullOr',
+                                                '$.answers.section1.q1',
+                                                '$.answers.section2.q2',
+                                                '$.answers.nullSection.nullQuestion'
+                                            ]
+                                        },
+                                        {
+                                            target: 'section5'
+                                        }
+                                    ]
+                                }
+                            },
+                            section4: {},
+                            section5: {}
+                        }
+                    }
+                });
+                router.next({q1: false});
+                router.next({q2: false});
+                const nextSectionId = router.next({q3: false}).id;
+
+                expect(nextSectionId).toEqual('section5');
+            });
+
+            it('should return true if noNullOr any answer is true and some answers are null', () => {
+                const router = qRouter({
+                    routes: {
+                        initial: 'section1',
+                        states: {
+                            section1: {
+                                on: {
+                                    ANSWER: [
+                                        {
+                                            target: 'section2'
+                                        }
+                                    ]
+                                }
+                            },
+                            section2: {
+                                on: {
+                                    ANSWER: [
+                                        {
+                                            target: 'section3'
+                                        }
+                                    ]
+                                }
+                            },
+                            section3: {
+                                on: {
+                                    ANSWER: [
+                                        {
+                                            target: 'section4',
+                                            cond: [
+                                                'noNullOr',
+                                                '$.answers.nullSection.nullQuestion',
+                                                '$.answers.section1.q1',
+                                                '$.answers.section2.q2',
+                                                '$.answers.section2.q3'
+                                            ]
+                                        },
+                                        {
+                                            target: 'section5'
+                                        }
+                                    ]
+                                }
+                            },
+                            section4: {},
+                            section5: {}
+                        }
+                    }
+                });
+                router.next({q1: false});
+                router.next({q2: true});
+                const nextSectionId = router.next({q3: false}).id;
+
+                expect(nextSectionId).toEqual('section4');
+            });
         });
     });
 


### PR DESCRIPTION
This commit adds the operator noNullOr. This operator accpets
multiple boolean answers and returns true if any of them are true.
This operator differs from a regular OR because it also handles
null questions - i.e. questions that were not asked as part of the
journey.