### PR TITLE
Add functionality to retract answers

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,7 @@ function qRouter(spec) {
     const q = {...spec};
     const fsm = createMachine(q.routes);
     q.answers = q.answers || {};
+    q.retractedAnswers = q.retractedAnswers || {};
     q.progress = q.progress || [fsm.initialState.value];
     q.currentSectionId = q.currentSectionId || q.progress[q.progress.length - 1];
 
@@ -72,13 +73,51 @@ function qRouter(spec) {
         };
     }
 
-    function setProgress(sectionId) {
+    function restoreAnswer(sectionId) {
+        const answerToRestore = q.retractedAnswers[sectionId];
+
+        if (answerToRestore !== undefined) {
+            q.answers[sectionId] = answerToRestore;
+            delete q.retractedAnswers[sectionId];
+        }
+
+        return answerToRestore;
+    }
+
+    function retractAnswers(sectionIds) {
+        const retractedAnswers = [];
+
+        sectionIds.forEach(sectionId => {
+            const currentAnswer = q.answers[sectionId];
+
+            if (currentAnswer !== undefined) {
+                q.retractedAnswers[sectionId] = currentAnswer;
+                delete q.answers[sectionId];
+
+                retractedAnswers.push(currentAnswer);
+            }
+        });
+
+        return retractedAnswers;
+    }
+
+    function addProgress(sectionId) {
         // If this section hasn't already been visited, add it to the progress
         if (!q.progress.includes(sectionId)) {
             q.progress.push(sectionId);
+
+            restoreAnswer(sectionId);
         }
 
         return setCurrent(sectionId);
+    }
+
+    function removeProgress(startIndex) {
+        const removedSectionIds = q.progress.splice(startIndex);
+
+        retractAnswers(removedSectionIds);
+
+        return removedSectionIds;
     }
 
     // get/set
@@ -114,7 +153,7 @@ function qRouter(spec) {
 
                     // Remove all progress after the cascade index
                     if (cascadeIndex > -1) {
-                        q.progress.length = cascadeIndex;
+                        removeProgress(cascadeIndex);
                     }
                 }
             }
@@ -122,7 +161,7 @@ function qRouter(spec) {
 
         const state = fsm.transition({value: currentSectionId}, event, q);
 
-        return setProgress(state.value);
+        return addProgress(state.value);
     }
 
     function previous(currentSectionId = q.currentSectionId) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "q-router",
-    "version": "2.5.2",
+    "version": "2.5.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "q-router",
-    "version": "2.5.2",
+    "version": "2.5.3",
     "description": "Provides methods for navigating a questionnaire based on defined routing rules.",
     "homepage": "",
     "author": "CICA",

--- a/test/routing.test.js
+++ b/test/routing.test.js
@@ -285,7 +285,154 @@ describe('qRouter tests', () => {
                     });
                 });
 
-                describe('Cascade: updating answer affects existing progress', () => {
+                it('should only use answers that are on pages in progress', () => {
+                    // for more details around this test - https://github.com/CriminalInjuriesCompensationAuthority/q-router/issues/16
+                    const router = createQRouter({
+                        routes: {
+                            initial: 'a',
+                            states: {
+                                a: {
+                                    on: {
+                                        ANSWER: [
+                                            {
+                                                target: 'b',
+                                                cond: ['==', '$.answers.a.q1', 'foo']
+                                            },
+                                            {
+                                                target: 'c',
+                                                cond: ['==', '$.answers.a.q1', 'bar']
+                                            }
+                                        ]
+                                    }
+                                },
+                                b: {
+                                    on: {
+                                        ANSWER: [{target: 'd'}]
+                                    }
+                                },
+                                c: {
+                                    on: {
+                                        ANSWER: [{target: 'd'}]
+                                    }
+                                },
+                                d: {
+                                    on: {
+                                        ANSWER: [
+                                            {
+                                                target: 'e',
+                                                cond: ['==', '$.answers.b.q1', 1]
+                                            },
+                                            {
+                                                target: 'f',
+                                                cond: ['==', '$.answers.c.q1', 1]
+                                            }
+                                        ]
+                                    }
+                                },
+                                e: {type: 'final'},
+                                f: {type: 'final'}
+                            }
+                        }
+                    });
+
+                    // current is a
+                    router.next({q1: 'foo'}); // a's answer, goto b
+                    router.next({q1: 1}); // b's answer, goto d
+                    router.previous(); // backtrack to b
+                    router.previous(); // backtrack to a
+                    router.next({q1: 'bar'}); // a's answer, goto c
+                    router.next({q1: 1}); // c's answer, goto d
+                    router.next({q1: 1}); // d's answer, goto f
+
+                    const current = router.current();
+
+                    expect(current.id).toEqual('f');
+                });
+
+                describe('Restore answers', () => {
+                    it('should restore any retracted answers for a section added to progress', () => {
+                        const router = createQRouter({
+                            routes: {
+                                initial: 'a',
+                                states: {
+                                    a: {
+                                        on: {
+                                            ANSWER: [
+                                                {
+                                                    target: 'b',
+                                                    cond: ['==', '$.answers.a.q1', 'foo']
+                                                },
+                                                {
+                                                    target: 'c',
+                                                    cond: ['==', '$.answers.a.q1', 'bar']
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    b: {
+                                        on: {
+                                            ANSWER: [{target: 'd'}]
+                                        }
+                                    },
+                                    c: {
+                                        on: {
+                                            ANSWER: [{target: 'd'}]
+                                        }
+                                    },
+                                    d: {
+                                        on: {
+                                            ANSWER: [
+                                                {
+                                                    target: 'e',
+                                                    cond: ['==', '$.answers.b.q1', 1]
+                                                },
+                                                {
+                                                    target: 'f',
+                                                    cond: ['==', '$.answers.c.q1', 1]
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    e: {type: 'final'},
+                                    f: {type: 'final'}
+                                }
+                            }
+                        });
+
+                        // current is a
+                        router.next({q1: 'foo'}); // a's answer, goto b
+                        router.next({q1: 1}); // b's answer, goto d
+
+                        router.previous(); // backtrack to b
+                        router.previous(); // backtrack to a
+
+                        router.next({q1: 'bar'}); // a's answer, goto c
+                        router.next({q1: 1}); // c's answer, goto d
+
+                        router.previous(); // backtrack to c
+                        router.previous(); // backtrack to a
+
+                        router.next({q1: 'foo'}); // a's answer, goto b - should restore b's previous answer
+
+                        const questionnaire = router.current().context;
+
+                        expect(questionnaire.answers).toEqual({
+                            a: {
+                                q1: 'foo'
+                            },
+                            b: {
+                                q1: 1
+                            }
+                        });
+                        expect(questionnaire.retractedAnswers).toEqual({
+                            c: {
+                                q1: 1
+                            }
+                        });
+                    });
+                });
+
+                describe('Cascade: updating answer removes subsequent progress', () => {
                     describe('Section relies on its own answer for routing', () => {
                         it('should clear affected progress', () => {
                             const router = createQRouter({
@@ -551,6 +698,7 @@ describe('qRouter tests', () => {
 
                         // Currently the router only detects cascade at the page level instead of the answers on the page.
                         // TODO: Get this test passing for question level detection
+                        // eslint-disable-next-line jest/no-commented-out-tests
                         // it('should leave progress unaffected if a changed answer does not cause a cascade #2', () => {
                         //     const router = createQRouter({
                         //         routes: {
@@ -600,6 +748,157 @@ describe('qRouter tests', () => {
                         //     expect(section.id).toEqual('d');
                         //     expect(section.context.progress).toEqual(['a', 'b', 'c', 'd']);
                         // });
+                    });
+
+                    describe('Retract answers', () => {
+                        it('should retract answers for sections removed from progress', () => {
+                            const router = createQRouter({
+                                routes: {
+                                    initial: 'a',
+                                    states: {
+                                        a: {
+                                            on: {
+                                                ANSWER: [
+                                                    {
+                                                        target: 'b',
+                                                        cond: ['==', '$.answers.a.q1', 'foo']
+                                                    },
+                                                    {
+                                                        target: 'c',
+                                                        cond: ['==', '$.answers.a.q1', 'bar']
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        b: {
+                                            on: {
+                                                ANSWER: [{target: 'd'}]
+                                            }
+                                        },
+                                        c: {
+                                            on: {
+                                                ANSWER: [{target: 'd'}]
+                                            }
+                                        },
+                                        d: {
+                                            on: {
+                                                ANSWER: [
+                                                    {
+                                                        target: 'e',
+                                                        cond: ['==', '$.answers.b.q1', 1]
+                                                    },
+                                                    {
+                                                        target: 'f',
+                                                        cond: ['==', '$.answers.c.q1', 1]
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        e: {type: 'final'},
+                                        f: {type: 'final'}
+                                    }
+                                }
+                            });
+
+                            // current is a
+                            router.next({q1: 'foo'}); // a's answer, goto b
+                            router.next({q1: 1}); // b's answer, goto d
+                            router.next({q1: 1}); // d's answer, goto e
+
+                            router.previous(); // backtrack to d
+                            router.previous(); // backtrack to b
+                            router.previous(); // backtrack to a
+
+                            router.next({q1: 'bar'}); // a's answer, goto c - causes cascade removing b, d, e from progress
+
+                            const questionnaire = router.current().context;
+
+                            expect(questionnaire.progress).toEqual(['a', 'c']);
+                            expect(questionnaire.answers).toEqual({
+                                a: {
+                                    q1: 'bar'
+                                }
+                            });
+                            expect(questionnaire.retractedAnswers).toEqual({
+                                b: {
+                                    q1: 1
+                                },
+                                d: {
+                                    q1: 1
+                                }
+                            });
+                        });
+
+                        it('should retract no answers if no progress is removed', () => {
+                            const router = createQRouter({
+                                routes: {
+                                    initial: 'a',
+                                    states: {
+                                        a: {
+                                            on: {
+                                                ANSWER: [
+                                                    {
+                                                        target: 'b',
+                                                        cond: ['==', '$.answers.a.q1', 'foo']
+                                                    },
+                                                    {
+                                                        target: 'c',
+                                                        cond: ['==', '$.answers.a.q1', 'bar']
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        b: {
+                                            on: {
+                                                ANSWER: [{target: 'd'}]
+                                            }
+                                        },
+                                        c: {
+                                            on: {
+                                                ANSWER: [{target: 'd'}]
+                                            }
+                                        },
+                                        d: {
+                                            on: {
+                                                ANSWER: [
+                                                    {
+                                                        target: 'e',
+                                                        cond: ['==', '$.answers.b.q1', 1]
+                                                    },
+                                                    {
+                                                        target: 'f',
+                                                        cond: ['==', '$.answers.c.q1', 1]
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        e: {type: 'final'},
+                                        f: {type: 'final'}
+                                    }
+                                }
+                            });
+
+                            // current is a
+                            router.next({q1: 'bar'}); // a's answer, goto c
+                            router.next({q1: 1}); // c's answer, goto d
+                            router.next({q1: 1}); // d's answer, goto f
+
+                            const questionnaire = router.current().context;
+
+                            expect(questionnaire.progress).toEqual(['a', 'c', 'd', 'f']);
+                            expect(questionnaire.answers).toEqual({
+                                a: {
+                                    q1: 'bar'
+                                },
+                                c: {
+                                    q1: 1
+                                },
+                                d: {
+                                    q1: 1
+                                }
+                            });
+                            expect(questionnaire.retractedAnswers).toEqual({});
+                        });
                     });
                 });
             });
@@ -893,7 +1192,7 @@ describe('qRouter tests', () => {
                     }
                 });
 
-                const nextSectionId = router.next({q1: '2018-12-01T00:00Z'}).id;
+                const nextSectionId = router.next({q1: '2099-12-01T00:00Z'}).id;
 
                 expect(nextSectionId).toEqual('section3');
             });
@@ -1046,1196 +1345,4 @@ describe('qRouter tests', () => {
             });
         });
     });
-
-    // #################################################################################################################################
-    // #################################################################################################################################
-    // #################################################################################################################################
-    // #################################################################################################################################
-    // #################################################################################################################################
-
-    //     describe('qRouter', () => {
-    //         let questionnaire;
-
-    //         beforeEach(() => {
-    //             questionnaire = {
-    //                 routes: {
-    //                     initial: 'a',
-    //                     states: {
-    //                         a: {
-    //                             on: {
-    //                                 ANSWER: 'b'
-    //                             }
-    //                         },
-    //                         b: {
-    //                             on: {
-    //                                 ANSWER: 'c'
-    //                             }
-    //                         },
-    //                         c: {
-    //                             on: {
-    //                                 ANSWER: 'd'
-    //                             }
-    //                         },
-    //                         d: {}
-    //                     }
-    //                 }
-    //             };
-    //         });
-
-    //         it('should start at the specified section', () => {
-    //             const router = qRouter(questionnaire);
-
-    //             expect(router.current().id).toEqual('a');
-    //         });
-
-    //         it('should store a supplied value against the current state', () => {
-    //             const router = qRouter(questionnaire);
-    //             const section = router.next('ANSWER', {
-    //                 q1: 'value of answer'
-    //             });
-
-    //             expect(section.context.answers).toEqual({
-    //                 a: {
-    //                     q1: {value: 'value of answer'}
-    //                 }
-    //             });
-    //         });
-
-    //         it('should store a supplied value with multiple keys against the current state', () => {
-    //             const router = qRouter(questionnaire);
-    //             const section = router.next('ANSWER', {
-    //                 q1: 'value of answer 1',
-    //                 q2: 'value of answer 2'
-    //             });
-
-    //             expect(section.context.answers).toEqual({
-    //                 a: {
-    //                     q1: {value: 'value of answer 1'},
-    //                     q2: {value: 'value of answer 2'}
-    //                 }
-    //             });
-    //         });
-
-    //         it('should overwrite the previous answer when the question is edited', () => {
-    //             const router = qRouter(questionnaire);
-
-    //             // answer questions
-    //             router.next('ANSWER', {
-    //                 q1: 'value of answer 1',
-    //                 q2: 'value of answer 2'
-    //             });
-
-    //             // go back to question
-    //             router.previous();
-
-    //             // edit question
-    //             const section = router.next('ANSWER', {
-    //                 q1: 'value of answer 1 edited',
-    //                 q2: 'value of answer 2 edited'
-    //             });
-
-    //             expect(section.context.answers).toEqual({
-    //                 a: {
-    //                     q1: {value: 'value of answer 1 edited'},
-    //                     q2: {value: 'value of answer 2 edited'}
-    //                 }
-    //             });
-    //         });
-
-    //         describe('Repeatable sections', () => {
-    //             let questionnaireWithRepeatableSections;
-
-    //             beforeEach(() => {
-    //                 questionnaireWithRepeatableSections = {
-    //                     routes: {
-    //                         initial: 'p-number-of-attackers',
-    //                         states: {
-    //                             'p-number-of-attackers': {
-    //                                 on: {
-    //                                     ANSWER: 'p-attacker-names'
-    //                                 }
-    //                             },
-    //                             'p-attacker-names': {
-    //                                 repeatable: true,
-    //                                 on: {
-    //                                     ANSWER: [
-    //                                         {
-    //                                             target: 'p-attacker-names',
-    //                                             // This will repeat the enter attacker name question, based on the answer given to how many attackers were involved
-    //                                             // e.g. 3 attackers, for each attacker enter their name
-    //                                             cond: [
-    //                                                 'answeredLessThan',
-    //                                                 'p-attacker-names',
-    //                                                 'q-number-of-attackers'
-    //                                             ]
-    //                                         },
-    //                                         {
-    //                                             target: 'section3'
-    //                                         }
-    //                                     ]
-    //                                 }
-    //                             },
-    //                             section3: {}
-    //                         }
-    //                     }
-    //                 };
-    //             });
-
-    //             it('should allow a page to be repeated', () => {
-    //                 const router = qRouter(questionnaireWithRepeatableSections);
-
-    //                 // answer questions
-    //                 router.next('ANSWER', {'q-number-of-attackers': 2});
-    //                 router.next('ANSWER', {
-    //                     'q-attacker-first-name': 'Peppa',
-    //                     'q-attacker-last-name': 'Pig'
-    //                 });
-    //                 router.next('ANSWER', {
-    //                     'q-attacker-first-name': 'Rebecca',
-    //                     'q-attacker-last-name': 'Rabbit'
-    //                 });
-    //                 const section = router.next('ANSWER', {bla: 3});
-
-    //                 expect(section.context.answers).toEqual({
-    //                     'p-number-of-attackers': {
-    //                         'q-number-of-attackers': {value: 2}
-    //                     },
-    //                     'p-attacker-names': [
-    //                         {
-    //                             'q-attacker-first-name': {value: 'Peppa'},
-    //                             'q-attacker-last-name': {value: 'Pig'}
-    //                         },
-    //                         {
-    //                             'q-attacker-first-name': {value: 'Rebecca'},
-    //                             'q-attacker-last-name': {value: 'Rabbit'}
-    //                         }
-    //                     ],
-    //                     section3: {
-    //                         bla: {value: 3}
-    //                     }
-    //                 });
-    //             });
-
-    //             it('should be able to start with a self referencing repeatable section', () => {
-    //                 const router = qRouter({
-    //                     routes: {
-    //                         initial: 'a',
-    //                         states: {
-    //                             a: {
-    //                                 repeatable: true,
-    //                                 on: {
-    //                                     ANSWER: [
-    //                                         {
-    //                                             target: 'a',
-    //                                             cond: ['answeredLessThan', 'a', 3]
-    //                                         },
-    //                                         {
-    //                                             target: 'b'
-    //                                         }
-    //                                     ]
-    //                                 }
-    //                             },
-    //                             b: {
-    //                                 on: {
-    //                                     ANSWER: 'c'
-    //                                 }
-    //                             },
-    //                             c: {
-    //                                 on: {
-    //                                     ANSWER: 'd'
-    //                                 }
-    //                             },
-    //                             d: {}
-    //                         }
-    //                     }
-    //                 });
-
-    //                 router.next('ANSWER', {aQ1: 1});
-    //                 router.next('ANSWER', {aQ2: 2});
-    //                 router.next('ANSWER', {aQ3: 3});
-    //                 router.next('ANSWER', {bQ1: 4});
-    //                 const section = router.next('ANSWER', {cQ1: 5});
-
-    //                 expect(section.context.progress).toEqual(['a', 'a/2', 'a/3', 'b', 'c', 'd']);
-    //                 expect(section.context.answers).toEqual({
-    //                     a: [{aQ1: {value: 1}}, {aQ2: {value: 2}}, {aQ3: {value: 3}}],
-    //                     b: {bQ1: {value: 4}},
-    //                     c: {cQ1: {value: 5}}
-    //                 });
-    //             });
-
-    //             it('should be able to start with a multi section repeatable', () => {
-    //                 const router = qRouter({
-    //                     routes: {
-    //                         initial: 'a',
-    //                         states: {
-    //                             a: {
-    //                                 repeatable: true,
-    //                                 on: {
-    //                                     ANSWER: 'b'
-    //                                 }
-    //                             },
-    //                             b: {
-    //                                 repeatable: true,
-    //                                 on: {
-    //                                     ANSWER: 'c'
-    //                                 }
-    //                             },
-    //                             c: {
-    //                                 repeatable: true,
-    //                                 on: {
-    //                                     ANSWER: [
-    //                                         {
-    //                                             target: 'a',
-    //                                             cond: ['answeredLessThan', 'c', 3]
-    //                                         },
-    //                                         {
-    //                                             target: 'd'
-    //                                         }
-    //                                     ]
-    //                                 }
-    //                             },
-    //                             d: {}
-    //                         }
-    //                     }
-    //                 });
-
-    //                 router.next('ANSWER', {aQ1: 1});
-    //                 router.next('ANSWER', {bQ1: 2});
-    //                 router.next('ANSWER', {cQ1: 3});
-    //                 router.next('ANSWER', {aQ1: 4});
-    //                 router.next('ANSWER', {bQ1: 5});
-    //                 router.next('ANSWER', {cQ1: 6});
-    //                 router.next('ANSWER', {aQ1: 7});
-    //                 router.next('ANSWER', {bQ1: 8});
-    //                 const section = router.next('ANSWER', {cQ1: 9});
-
-    //                 expect(section.context.progress).toEqual([
-    //                     'a',
-    //                     'b',
-    //                     'c',
-    //                     'a/2',
-    //                     'b/2',
-    //                     'c/2',
-    //                     'a/3',
-    //                     'b/3',
-    //                     'c/3',
-    //                     'd'
-    //                 ]);
-    //                 expect(section.context.answers).toEqual({
-    //                     a: [{aQ1: {value: 1}}, {aQ1: {value: 4}}, {aQ1: {value: 7}}],
-    //                     b: [{bQ1: {value: 2}}, {bQ1: {value: 5}}, {bQ1: {value: 8}}],
-    //                     c: [{cQ1: {value: 3}}, {cQ1: {value: 6}}, {cQ1: {value: 9}}]
-    //                 });
-    //             });
-
-    //             it('should return a sectionId that contains the array index of the stored answer', () => {
-    //                 const router = qRouter(questionnaireWithRepeatableSections);
-
-    //                 // answer questions
-    //                 router.next('ANSWER', {'q-number-of-attackers': 3});
-    //                 router.next('ANSWER', {
-    //                     'q-attacker-first-name': 'Peppa1',
-    //                     'q-attacker-last-name': 'Pig1'
-    //                 });
-    //                 router.next('ANSWER', {
-    //                     'q-attacker-first-name': 'Peppa2',
-    //                     'q-attacker-last-name': 'Pig2'
-    //                 });
-    //                 const section = router.next('ANSWER', {
-    //                     'q-attacker-first-name': 'Peppa3',
-    //                     'q-attacker-last-name': 'Pig3'
-    //                 });
-
-    //                 expect(section.context.progress).toEqual([
-    //                     'p-number-of-attackers',
-    //                     'p-attacker-names',
-    //                     'p-attacker-names/2',
-    //                     'p-attacker-names/3',
-    //                     'section3'
-    //                 ]);
-    //             });
-
-    //             it('should overwrite the previous answer when the question is edited', () => {
-    //                 const router = qRouter(questionnaireWithRepeatableSections);
-
-    //                 // answer questions
-    //                 router.next('ANSWER', {'q-number-of-attackers': 4});
-    //                 router.next('ANSWER', {
-    //                     'q-attacker-first-name': 'Peppa',
-    //                     'q-attacker-last-name': 'Pig'
-    //                 });
-    //                 router.next('ANSWER', {
-    //                     'q-attacker-first-name': 'Rebecca',
-    //                     'q-attacker-last-name': 'Rabbit'
-    //                 });
-    //                 router.next('ANSWER', {
-    //                     'q-attacker-first-name': 'Suzie',
-    //                     'q-attacker-last-name': 'Sheep'
-    //                 });
-    //                 router.next('ANSWER', {
-    //                     'q-attacker-first-name': 'Mummy',
-    //                     'q-attacker-last-name': 'Pig'
-    //                 });
-    //                 router.next('ANSWER', {bla: 3});
-
-    //                 // go back to question
-    //                 router.previous(); // Mummy Pig
-    //                 router.previous(); // Suzie Sheep
-    //                 router.previous(); // Rebecca Rabbit
-
-    //                 // edit question Rebecca Rabbit to Candy Cat
-    //                 const section = router.next('ANSWER', {
-    //                     'q-attacker-first-name': 'Candy',
-    //                     'q-attacker-last-name': 'Cat'
-    //                 });
-
-    //                 expect(section.context.answers).toEqual({
-    //                     'p-number-of-attackers': {
-    //                         'q-number-of-attackers': {value: 4}
-    //                     },
-    //                     'p-attacker-names': [
-    //                         {
-    //                             'q-attacker-first-name': {value: 'Peppa'},
-    //                             'q-attacker-last-name': {value: 'Pig'}
-    //                         },
-    //                         {
-    //                             'q-attacker-first-name': {value: 'Candy'},
-    //                             'q-attacker-last-name': {value: 'Cat'}
-    //                         },
-    //                         {
-    //                             'q-attacker-first-name': {value: 'Suzie'},
-    //                             'q-attacker-last-name': {value: 'Sheep'}
-    //                         },
-    //                         {
-    //                             'q-attacker-first-name': {value: 'Mummy'},
-    //                             'q-attacker-last-name': {value: 'Pig'}
-    //                         }
-    //                     ],
-    //                     section3: {
-    //                         bla: {value: 3}
-    //                     }
-    //                 });
-    //             });
-
-    //             it('should allow multiple pages to be repeated', () => {
-    //                 const router = qRouter({
-    //                     routes: {
-    //                         initial: 'a',
-    //                         states: {
-    //                             a: {
-    //                                 on: {
-    //                                     ANSWER: 'b'
-    //                                 }
-    //                             },
-    //                             b: {
-    //                                 on: {
-    //                                     ANSWER: 'c'
-    //                                 }
-    //                             },
-    //                             c: {
-    //                                 repeatable: true,
-    //                                 on: {
-    //                                     ANSWER: 'd'
-    //                                 }
-    //                             },
-    //                             d: {
-    //                                 repeatable: true,
-    //                                 on: {
-    //                                     ANSWER: 'e'
-    //                                 }
-    //                             },
-    //                             e: {
-    //                                 repeatable: true,
-    //                                 on: {
-    //                                     ANSWER: [
-    //                                         {
-    //                                             target: 'c',
-    //                                             cond: ['answeredLessThan', 'c', 3]
-    //                                         },
-    //                                         {
-    //                                             target: 'f'
-    //                                         }
-    //                                     ]
-    //                                 }
-    //                             },
-    //                             f: {
-    //                                 on: {
-    //                                     ANSWER: 'g'
-    //                                 }
-    //                             },
-    //                             g: {}
-    //                         }
-    //                     }
-    //                 });
-
-    //                 // answer questions
-    //                 router.next('ANSWER', {'question-a': 1}); // a
-    //                 router.next('ANSWER', {'question-b': 1}); // b
-    //                 router.next('ANSWER', {'question-c': 1}); // c
-    //                 router.next('ANSWER', {'question-d': 1}); // d
-    //                 router.next('ANSWER', {'question-e': 1}); // e
-    //                 router.next('ANSWER', {'question-c': 2}); // c2
-    //                 router.next('ANSWER', {'question-d': 2}); // d2
-    //                 router.next('ANSWER', {'question-e': 2}); // e2
-    //                 router.next('ANSWER', {'question-c': 3}); // c3
-    //                 router.next('ANSWER', {'question-d': 3}); // d3
-    //                 router.next('ANSWER', {'question-e': 3}); // e3
-    //                 router.next('ANSWER', {'question-f': 1}); // f
-    //                 const section = router.next('ANSWER', {'question-g': 1}); // g
-
-    //                 expect(section.context.answers).toEqual({
-    //                     a: {'question-a': {value: 1}},
-    //                     b: {'question-b': {value: 1}},
-    //                     c: [
-    //                         {'question-c': {value: 1}},
-    //                         {'question-c': {value: 2}},
-    //                         {'question-c': {value: 3}}
-    //                     ],
-    //                     d: [
-    //                         {'question-d': {value: 1}},
-    //                         {'question-d': {value: 2}},
-    //                         {'question-d': {value: 3}}
-    //                     ],
-    //                     e: [
-    //                         {'question-e': {value: 1}},
-    //                         {'question-e': {value: 2}},
-    //                         {'question-e': {value: 3}}
-    //                     ],
-    //                     f: {'question-f': {value: 1}},
-    //                     g: {'question-g': {value: 1}}
-    //                 });
-    //             });
-    //         });
-
-    //         it('should move to the next section according to the routing rules', () => {
-    //             const router = qRouter(questionnaire);
-
-    //             router.next('ANSWER');
-
-    //             expect(router.current().id).toEqual('b');
-    //         });
-
-    //         it('should track the routing progress', () => {
-    //             const router = qRouter(questionnaire);
-
-    //             router.next('ANSWER');
-    //             router.next('ANSWER');
-    //             const section = router.next('ANSWER');
-
-    //             expect(section.context.progress).toEqual(['a', 'b', 'c', 'd']);
-    //         });
-
-    //         it('should move to the previous state according to the progress', () => {
-    //             const router = qRouter(questionnaire);
-
-    //             router.next('ANSWER');
-    //             router.next('ANSWER');
-    //             router.previous();
-
-    //             expect(router.current().id).toEqual('b');
-    //         });
-
-    //         it('should move to the next section based on any conditions', () => {
-    //             const router = qRouter({
-    //                 routes: {
-    //                     initial: 'section1',
-    //                     states: {
-    //                         section1: {
-    //                             on: {
-    //                                 ANSWER: [
-    //                                     {target: 'section3', cond: ['==', 1, 2]},
-    //                                     {target: 'section2', cond: ['==', 2, 2]},
-    //                                     {target: 'section4', cond: ['==', 3, 2]}
-    //                                 ]
-    //                             }
-    //                         },
-    //                         section2: {
-    //                             on: {
-    //                                 ANSWER: [
-    //                                     {target: 'section4', cond: ['==', 2, 2]},
-    //                                     {target: 'section3', cond: ['==', 1, 2]}
-    //                                 ]
-    //                             }
-    //                         },
-    //                         section3: {
-    //                             on: {
-    //                                 ANSWER: 'section4'
-    //                             }
-    //                         },
-    //                         section4: {}
-    //                     }
-    //                 }
-    //             });
-
-    //             router.next('ANSWER');
-    //             router.next('ANSWER');
-
-    //             expect(router.current().id).toEqual('section4');
-    //         });
-
-    //         it('should assume the condition is true if the "cond" attribute is omitted', () => {
-    //             const router = qRouter({
-    //                 routes: {
-    //                     initial: 'section1',
-    //                     states: {
-    //                         section1: {
-    //                             on: {
-    //                                 ANSWER: [
-    //                                     {target: 'section3', cond: ['==', 1, 2]},
-    //                                     {target: 'section2'}
-    //                                 ]
-    //                             }
-    //                         },
-    //                         section2: {},
-    //                         section3: {}
-    //                     }
-    //                 }
-    //             });
-
-    //             router.next('ANSWER');
-
-    //             expect(router.current().id).toEqual('section2');
-    //         });
-
-    //         it('should be able to use previous answers as data in conditions', () => {
-    //             const router = qRouter({
-    //                 routes: {
-    //                     initial: 'section1',
-    //                     states: {
-    //                         section1: {
-    //                             on: {
-    //                                 ANSWER: [
-    //                                     {
-    //                                         target: 'section3',
-    //                                         cond: ['==', '$.answers.section1.q1.value', 2]
-    //                                     },
-    //                                     {target: 'section2'}
-    //                                 ]
-    //                             }
-    //                         },
-    //                         section2: {},
-    //                         section3: {}
-    //                     }
-    //                 }
-    //             });
-
-    //             router.next('ANSWER', {
-    //                 q1: 2
-    //             });
-
-    //             expect(router.current().id).toEqual('section3');
-    //         });
-
-    //         it('should use the current progress as the initial state if available', () => {
-    //             questionnaire.progress = ['a', 'b', 'c'];
-
-    //             const router = qRouter(questionnaire);
-
-    //             expect(router.current().id).toEqual('c');
-    //         });
-
-    //         describe('Progress management', () => {
-    //             it('should start with the initial section in progress', () => {
-    //                 const router = qRouter(questionnaire);
-    //                 const section = router.current();
-    //                 expect(section.context.progress).toEqual(['a']);
-    //             });
-
-    //             it('should stop non-visited sections from being used', () => {
-    //                 const router = qRouter(questionnaire);
-    //                 const rxExpectedError = errorMessageToRegExp(
-    //                     `Failed to set the current section to id: "c". This section has not yet been visited.`
-    //                 );
-
-    //                 // Try and advance to section "c" which has not yet been visited
-    //                 expect(() => router.next('ANSWER', {'q-c': 1}, 'c')).toThrow(rxExpectedError);
-    //             });
-
-    //             describe('Given the following saved progress ["a", "b", "c", "d"]', () => {
-    //                 it('should remove any saved progress sectionIds after the current sectionId', () => {
-    //                     const router = qRouter(questionnaire);
-
-    //                     router.next('ANSWER', {'q-a': 1}, 'a');
-    //                     router.next('ANSWER', {'q-b': 1}, 'b');
-    //                     router.next('ANSWER', {'q-c': 1}, 'c');
-    //                     router.next('ANSWER', {'q-d': 1}, 'd');
-    //                     const section = router.next('ANSWER', {'q-a': 2}, 'a');
-
-    //                     expect(section.context.progress).toEqual(['a', 'b']);
-    //                 });
-    //             });
-    //         });
-
-    //         it('should return the next section id from the "next" method', () => {
-    //             const router = qRouter(questionnaire);
-    //             const nextSectionId = router.next('ANSWER', {aQ1: true}).id;
-
-    //             expect(nextSectionId).toEqual('b');
-    //         });
-
-    //         it('should return the previous section id from the "previous" method', () => {
-    //             const router = qRouter(questionnaire);
-
-    //             router.next('ANSWER', {aQ1: true});
-    //             router.next('ANSWER', {bQ1: true});
-    //             router.next('ANSWER', {cQ1: true});
-
-    //             const previousSectionId = router.previous().id;
-
-    //             expect(previousSectionId).toEqual('c');
-    //         });
-
-    //         describe('Edit from summary section', () => {
-    //             it('should return to the summary section if the edit has no cascading affect', () => {
-    //                 const router = qRouter({
-    //                     routes: {
-    //                         initial: 'a',
-    //                         states: {
-    //                             a: {
-    //                                 on: {
-    //                                     ANSWER: 'b'
-    //                                 }
-    //                             },
-    //                             b: {
-    //                                 on: {
-    //                                     ANSWER: 'c',
-    //                                     EDIT: [
-    //                                         {
-    //                                             target: 'summary',
-    //                                             cond: ['noCascade', 'b']
-    //                                         }
-    //                                     ]
-    //                                 }
-    //                             },
-    //                             c: {
-    //                                 on: {
-    //                                     ANSWER: 'summary'
-    //                                 }
-    //                             },
-    //                             summary: {}
-    //                         }
-    //                     }
-    //                 });
-
-    //                 router.next('ANSWER', {aQ1: true});
-    //                 router.next('ANSWER', {bQ1: true});
-    //                 router.next('ANSWER', {cQ1: true});
-
-    //                 const section = router.next('EDIT', {bQ1: false}, 'b');
-
-    //                 expect(section.context.progress).toEqual(['a', 'b', 'c', 'summary']);
-    //                 expect(section.id).toEqual('summary');
-    //                 expect(section.context.answers).toEqual({
-    //                     a: {aQ1: {value: true}},
-    //                     b: {bQ1: {value: false}},
-    //                     c: {cQ1: {value: true}}
-    //                 });
-    //             });
-
-    //             it('should go to the next section if the edit has a cascading affect', () => {
-    //                 const router = qRouter({
-    //                     routes: {
-    //                         initial: 'a',
-    //                         states: {
-    //                             a: {
-    //                                 on: {
-    //                                     ANSWER: 'b'
-    //                                 }
-    //                             },
-    //                             b: {
-    //                                 on: {
-    //                                     ANSWER: 'c',
-    //                                     EDIT: [
-    //                                         {
-    //                                             target: 'summary',
-    //                                             cond: ['noCascade', 'b']
-    //                                         },
-    //                                         {
-    //                                             target: 'c'
-    //                                         }
-    //                                     ]
-    //                                 }
-    //                             },
-    //                             c: {
-    //                                 on: {
-    //                                     ANSWER: [
-    //                                         {
-    //                                             target: 'summary',
-    //                                             cond: ['==', '$.answers.b.bQ1.value', true]
-    //                                         }
-    //                                     ]
-    //                                 }
-    //                             },
-    //                             summary: {}
-    //                         }
-    //                     }
-    //                 });
-
-    //                 router.next('ANSWER', {aQ1: true});
-    //                 router.next('ANSWER', {bQ1: true});
-    //                 router.next('ANSWER', {cQ1: true});
-
-    //                 const section = router.next('EDIT', {bQ1: false}, 'b');
-
-    //                 expect(section.context.progress).toEqual(['a', 'b', 'c']);
-    //                 expect(section.id).toEqual('c');
-    //                 expect(section.context.answers).toEqual({
-    //                     a: {aQ1: {value: true}},
-    //                     b: {bQ1: {value: false}},
-    //                     c: {cQ1: {value: true}}
-    //                 });
-    //             });
-
-    //             describe('Repeating sections', () => {
-    //                 it('should return to the summary section if the edit has no cascading affect', () => {
-    //                     const router = qRouter({
-    //                         routes: {
-    //                             initial: 'a',
-    //                             states: {
-    //                                 a: {
-    //                                     repeatable: true,
-    //                                     on: {
-    //                                         ANSWER: [
-    //                                             {
-    //                                                 target: 'a',
-    //                                                 cond: ['answeredLessThan', 'a', 3]
-    //                                             },
-    //                                             {
-    //                                                 target: 'b'
-    //                                             }
-    //                                         ],
-    //                                         EDIT: [
-    //                                             {
-    //                                                 target: 'summary',
-    //                                                 cond: ['noCascade', 'a']
-    //                                             },
-    //                                             {
-    //                                                 target: 'b'
-    //                                             }
-    //                                         ]
-    //                                     }
-    //                                 },
-    //                                 b: {
-    //                                     on: {
-    //                                         ANSWER: 'c'
-    //                                     }
-    //                                 },
-    //                                 c: {
-    //                                     on: {
-    //                                         ANSWER: 'summary'
-    //                                     }
-    //                                 },
-    //                                 summary: {}
-    //                             }
-    //                         }
-    //                     });
-
-    //                     router.next('ANSWER', {aQ1: 1});
-    //                     router.next('ANSWER', {aQ2: 2});
-    //                     router.next('ANSWER', {aQ3: 3});
-    //                     router.next('ANSWER', {bQ1: 4});
-    //                     router.next('ANSWER', {cQ1: 5});
-
-    //                     const result = router.next('EDIT', {aQ2: 99}, 'a/2');
-
-    //                     expect(result.context.progress).toEqual([
-    //                         'a',
-    //                         'a/2',
-    //                         'a/3',
-    //                         'b',
-    //                         'c',
-    //                         'summary'
-    //                     ]);
-    //                 });
-
-    //                 describe('Edit causes cascading affect', () => {
-    //                     it('should go to the next section', () => {
-    //                         const router = qRouter({
-    //                             routes: {
-    //                                 initial: 'a',
-    //                                 states: {
-    //                                     a: {
-    //                                         repeatable: true,
-    //                                         on: {
-    //                                             ANSWER: [
-    //                                                 {
-    //                                                     target: 'a',
-    //                                                     cond: ['answeredLessThan', 'a', 3]
-    //                                                 },
-    //                                                 {
-    //                                                     target: 'b'
-    //                                                 }
-    //                                             ]
-    //                                         }
-    //                                     },
-    //                                     b: {
-    //                                         on: {
-    //                                             ANSWER: 'c',
-    //                                             EDIT: [
-    //                                                 {
-    //                                                     target: 'summary',
-    //                                                     cond: ['noCascade', 'b']
-    //                                                 },
-    //                                                 {
-    //                                                     target: 'c'
-    //                                                 }
-    //                                             ]
-    //                                         }
-    //                                     },
-    //                                     c: {
-    //                                         on: {
-    //                                             ANSWER: [
-    //                                                 {
-    //                                                     target: 'summary',
-    //                                                     cond: ['==', '$.answers.b.bQ1.value', 4]
-    //                                                 },
-    //                                                 {
-    //                                                     target: 'd'
-    //                                                 }
-    //                                             ]
-    //                                         }
-    //                                     },
-    //                                     d: {},
-    //                                     summary: {}
-    //                                 }
-    //                             }
-    //                         });
-
-    //                         router.next('ANSWER', {aQ1: 1});
-    //                         router.next('ANSWER', {aQ2: 2});
-    //                         router.next('ANSWER', {aQ3: 3});
-    //                         router.next('ANSWER', {bQ1: 4});
-    //                         router.next('ANSWER', {cQ1: 5});
-
-    //                         const result = router.next('EDIT', {bQ1: 99}, 'b');
-
-    //                         expect(result.context.progress).toEqual(['a', 'a/2', 'a/3', 'b', 'c']);
-    //                     });
-
-    //                     it('should skip other repeated answers and go to next section', () => {
-    //                         const router = qRouter({
-    //                             routes: {
-    //                                 initial: 'a',
-    //                                 states: {
-    //                                     a: {
-    //                                         repeatable: true,
-    //                                         on: {
-    //                                             ANSWER: [
-    //                                                 {
-    //                                                     target: 'a',
-    //                                                     cond: ['answeredLessThan', 'a', 3]
-    //                                                 },
-    //                                                 {
-    //                                                     target: 'b'
-    //                                                 }
-    //                                             ],
-    //                                             EDIT: [
-    //                                                 {
-    //                                                     target: 'summary',
-    //                                                     cond: ['noCascade', 'a']
-    //                                                 },
-    //                                                 {
-    //                                                     target: 'b'
-    //                                                 }
-    //                                             ]
-    //                                         }
-    //                                     },
-    //                                     b: {
-    //                                         repeatable: true,
-    //                                         on: {
-    //                                             ANSWER: [
-    //                                                 {
-    //                                                     target: 'b',
-    //                                                     cond: ['==', '$.answers.a.0.aQ1.value', 0]
-    //                                                 },
-    //                                                 {
-    //                                                     target: 'c'
-    //                                                 }
-    //                                             ]
-    //                                         }
-    //                                     },
-    //                                     c: {
-    //                                         on: {
-    //                                             ANSWER: 'summary'
-    //                                         }
-    //                                     },
-    //                                     summary: {}
-    //                                 }
-    //                             }
-    //                         });
-
-    //                         router.next('ANSWER', {aQ1: 1});
-    //                         router.next('ANSWER', {aQ2: 2});
-    //                         router.next('ANSWER', {aQ3: 3});
-    //                         router.next('ANSWER', {bQ1: 4});
-    //                         router.next('ANSWER', {cQ1: 5});
-
-    //                         // Technically this result could/should be "a/3", however for the moment it'll skip it's siblings and go to the next available section e.g. "b"
-    //                         const result = router.next('EDIT', {aQ2: 0}, 'a/2');
-
-    //                         expect(result.context.progress).toEqual(['a', 'a/2', 'a/3', 'b']);
-    //                         expect(result.id).toEqual('b');
-    //                         expect(result.context.answers).toEqual({
-    //                             a: [{aQ1: {value: 1}}, {aQ2: {value: 0}}, {aQ3: {value: 3}}],
-    //                             b: [{bQ1: {value: 4}}],
-    //                             c: {cQ1: {value: 5}}
-    //                         });
-    //                     });
-    //                 });
-    //             });
-    //         });
-
-    //         it('should throw if a state has no target that evaluates to true', () => {
-    //             const router = qRouter({
-    //                 routes: {
-    //                     initial: 'section1',
-    //                     states: {
-    //                         section1: {
-    //                             on: {
-    //                                 ANSWER: [
-    //                                     {target: 'section3', cond: ['==', 1, 2]},
-    //                                     {target: 'section2', cond: ['==', 1, 2]},
-    //                                     {target: 'section4', cond: ['==', 1, 2]}
-    //                                 ]
-    //                             }
-    //                         },
-    //                         section2: {
-    //                             on: {
-    //                                 ANSWER: [
-    //                                     {target: 'section4', cond: ['==', 2, 2]},
-    //                                     {target: 'section3', cond: ['==', 1, 2]}
-    //                                 ]
-    //                             }
-    //                         },
-    //                         section3: {
-    //                             on: {
-    //                                 ANSWER: 'section4'
-    //                             }
-    //                         },
-    //                         section4: {}
-    //                     }
-    //                 }
-    //             });
-
-    //             const rxExpectedError = errorMessageToRegExp(
-    //                 'q-router - State "section1" has no target(s) that evaluate to "true"'
-    //             );
-
-    //             expect(() => router.next('ANSWER')).toThrow(rxExpectedError);
-    //         });
-
-    //         describe('Operators', () => {
-    //             it('should return true if dateExceedsTwoYearsFromToday', () => {
-    //                 const router = qRouter({
-    //                     routes: {
-    //                         initial: 'section1',
-    //                         states: {
-    //                             section1: {
-    //                                 on: {
-    //                                     ANSWER: [
-    //                                         {
-    //                                             target: 'section2',
-    //                                             cond: [
-    //                                                 'dateExceedsTwoYearsFromNow',
-    //                                                 '$.answers.section1.q1.value'
-    //                                             ]
-    //                                         },
-    //                                         {
-    //                                             target: 'section3'
-    //                                         }
-    //                                     ]
-    //                                 }
-    //                             },
-    //                             section2: {},
-    //                             section3: {}
-    //                         }
-    //                     }
-    //                 });
-
-    //                 const nextSectionId = router.next('ANSWER', {q1: '2017-02-01T00:00Z'}).id;
-
-    //                 expect(nextSectionId).toEqual('section2');
-    //             });
-
-    //             it('should return false if not dateExceedsTwoYearsFromToday', () => {
-    //                 const router = qRouter({
-    //                     routes: {
-    //                         initial: 'section1',
-    //                         states: {
-    //                             section1: {
-    //                                 on: {
-    //                                     ANSWER: [
-    //                                         {
-    //                                             target: 'section2',
-    //                                             cond: [
-    //                                                 'dateExceedsTwoYearsFromNow',
-    //                                                 '$.answers.section1.q1.value'
-    //                                             ]
-    //                                         },
-    //                                         {
-    //                                             target: 'section3'
-    //                                         }
-    //                                     ]
-    //                                 }
-    //                             },
-    //                             section2: {},
-    //                             section3: {}
-    //                         }
-    //                     }
-    //                 });
-
-    //                 const nextSectionId = router.next('ANSWER', {q1: '2018-12-01T00:00Z'}).id;
-
-    //                 expect(nextSectionId).toEqual('section3');
-    //             });
-
-    //             it('should return true if dateLessThanEighteenYearsAgo and date entered is less than 18 years ago', () => {
-    //                 const router = qRouter({
-    //                     routes: {
-    //                         initial: 'section1',
-    //                         states: {
-    //                             section1: {
-    //                                 on: {
-    //                                     ANSWER: [
-    //                                         {
-    //                                             target: 'section2',
-    //                                             cond: [
-    //                                                 'dateLessThanEighteenYearsAgo',
-    //                                                 '$.answers.section1.q1.value'
-    //                                             ]
-    //                                         },
-    //                                         {
-    //                                             target: 'section3'
-    //                                         }
-    //                                     ]
-    //                                 }
-    //                             },
-    //                             section2: {},
-    //                             section3: {}
-    //                         }
-    //                     }
-    //                 });
-
-    //                 const nextSectionId = router.next('ANSWER', {q1: '2015-02-01T00:00Z'}).id;
-
-    //                 expect(nextSectionId).toEqual('section2');
-    //             });
-
-    //             it('should return false if dateLessThanEighteenYearsAgo and date entered is more than 18 years ago', () => {
-    //                 const router = qRouter({
-    //                     routes: {
-    //                         initial: 'section1',
-    //                         states: {
-    //                             section1: {
-    //                                 on: {
-    //                                     ANSWER: [
-    //                                         {
-    //                                             target: 'section2',
-    //                                             cond: [
-    //                                                 'dateLessThanEighteenYearsAgo',
-    //                                                 '$.answers.section1.q1.value'
-    //                                             ]
-    //                                         },
-    //                                         {
-    //                                             target: 'section3'
-    //                                         }
-    //                                     ]
-    //                                 }
-    //                             },
-    //                             section2: {},
-    //                             section3: {}
-    //                         }
-    //                     }
-    //                 });
-    //                 const nextSectionId = router.next('ANSWER', {q1: '1985-02-01T00:00Z'}).id;
-
-    //                 expect(nextSectionId).toEqual('section3');
-    //             });
-
-    //             it('should return true if dateDifferenceGreaterThanTwoDays', () => {
-    //                 const router = qRouter({
-    //                     routes: {
-    //                         initial: 'section1',
-    //                         states: {
-    //                             section1: {
-    //                                 on: {
-    //                                     ANSWER: [
-    //                                         {
-    //                                             target: 'section2'
-    //                                         }
-    //                                     ]
-    //                                 }
-    //                             },
-    //                             section2: {
-    //                                 on: {
-    //                                     ANSWER: [
-    //                                         {
-    //                                             target: 'section3',
-    //                                             cond: [
-    //                                                 'dateDifferenceGreaterThanTwoDays',
-    //                                                 '$.answers.section1.q1.value',
-    //                                                 '$.answers.section2.q1.value'
-    //                                             ]
-    //                                         },
-    //                                         {
-    //                                             target: 'section4'
-    //                                         }
-    //                                     ]
-    //                                 }
-    //                             },
-    //                             section3: {},
-    //                             section4: {}
-    //                         }
-    //                     }
-    //                 });
-    //                 router.next('ANSWER', {q1: '2015-02-01T00:00Z'});
-    //                 const nextSectionId = router.next('ANSWER', {q1: '2015-02-05T00:00Z'}).id;
-
-    //                 expect(nextSectionId).toEqual('section3');
-    //             });
-
-    //             it('should return false if not dateDifferenceGreaterThanTwoDays', () => {
-    //                 const router = qRouter({
-    //                     routes: {
-    //                         initial: 'section1',
-    //                         states: {
-    //                             section1: {
-    //                                 on: {
-    //                                     ANSWER: [
-    //                                         {
-    //                                             target: 'section2'
-    //                                         }
-    //                                     ]
-    //                                 }
-    //                             },
-    //                             section2: {
-    //                                 on: {
-    //                                     ANSWER: [
-    //                                         {
-    //                                             target: 'section3',
-    //                                             cond: [
-    //                                                 'dateDifferenceGreaterThanTwoDays',
-    //                                                 '$.answers.section1.q1.value',
-    //                                                 '$.answers.section2.q1.value'
-    //                                             ]
-    //                                         },
-    //                                         {
-    //                                             target: 'section4'
-    //                                         }
-    //                                     ]
-    //                                 }
-    //                             },
-    //                             section3: {},
-    //                             section4: {}
-    //                         }
-    //                     }
-    //                 });
-    //                 router.next('ANSWER', {q1: '2015-02-01T00:00Z'});
-    //                 const nextSectionId = router.next('ANSWER', {q1: '2015-02-02T00:00Z'}).id;
-
-    //                 expect(nextSectionId).toEqual('section4');
-    //             });
-    //         });
-    //     });
 });


### PR DESCRIPTION
As a result of the issue: #16

This PR introduces the concept of retracting / restoring answers. Once a section is removed from progress, its answer is retracted. If a section is then revisited at a later date (added to progress), its answers (if any... might have landed on the section but not answered) will be restored. This ensures that only sections in progress have their answers considered when routing.