### PR TITLE
Set current parallel state to referrer machine state and return

### DIFF
--- a/lib/parallel.js
+++ b/lib/parallel.js
@@ -256,10 +256,12 @@ function createParallelRouter(spec) {
             currentState.context.routes.referrer &&
             currentSectionId === currentState.context.routes.initial
         ) {
-            previousResponse = current(currentState.context.routes.referrer);
-        } else {
-            previousResponse = machine.machine.previous(currentSectionId);
+            // The parallel router `.current()` method returns a fully populated spec that
+            // is ready to be consumed by the DCS. No need to update it further below.
+            return current(currentState.context.routes.referrer);
         }
+
+        previousResponse = machine.machine.previous(currentSectionId);
 
         if (previousResponse) {
             pq.currentSectionId = previousResponse.context.currentSectionId;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "q-router",
-    "version": "3.1.0",
+    "version": "3.1.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "q-router",
-            "version": "3.1.0",
+            "version": "3.1.1",
             "license": "MIT",
             "dependencies": {
                 "moment": "^2.24.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "q-router",
-    "version": "3.1.0",
+    "version": "3.1.1",
     "description": "Provides methods for navigating a questionnaire based on defined routing rules.",
     "homepage": "",
     "author": "CICA",

--- a/test/parallel.test.js
+++ b/test/parallel.test.js
@@ -551,6 +551,67 @@ describe('Parallel Router', () => {
 
                 expect(section.id).toEqual('a'); // #task1 machine.
             });
+
+            it('should retain the progress of the machine is routed from', () => {
+                const parallelRouter = createParallelRouter({
+                    currentSectionId: 'a',
+                    routes: {
+                        id: 'parallel-routes-test',
+                        type: 'parallel',
+                        states: {
+                            task1: {
+                                initial: 'a',
+                                currentSectionId: 'a',
+                                states: {
+                                    a: {
+                                        on: {
+                                            ANSWER: [
+                                                {
+                                                    target: 'b'
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    b: {
+                                        type: 'final'
+                                    }
+                                }
+                            },
+                            task2: {
+                                referrer: '#task1',
+                                initial: 'c',
+                                currentSectionId: 'c',
+                                states: {
+                                    c: {
+                                        on: {
+                                            ANSWER: [
+                                                {
+                                                    target: 'd'
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    d: {
+                                        type: 'final'
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    attributes: {
+                        q__roles: {}
+                    }
+                });
+
+                parallelRouter.next({}, 'c', 'ANSWER'); // d
+                parallelRouter.previous('d'); // c
+                parallelRouter.previous('c'); // #referrer
+
+                const section = parallelRouter.current();
+
+                expect(section.id).toEqual('a'); // #task1 machine.
+                expect(section.context.routes.states.task2.progress).toEqual(['c', 'd']);
+            });
         });
     });
 


### PR DESCRIPTION
The issue was that the parallel `.previous()` method was returning the wrong object when it was setting the state to that of the state of the referrer machine's "current".

i.e. if was getting a full DCS-friendly response from the parallel `.current()` method, and then updating properties on that object incorrectly. It does not need to change the response.

Fix:
Immediately return the value of `current(currentState.context.routes.referrer)` as it does not need any additional manipulation.